### PR TITLE
Allow the serializer to validate that age is an integer

### DIFF
--- a/puppy_store/puppies/tests/test_views.py
+++ b/puppy_store/puppies/tests/test_views.py
@@ -78,6 +78,13 @@ class CreateNewPuppyTest(TestCase):
             'color': 'White'
         }
 
+        self.invalid_payload_age = {
+            'name': 'Spot',
+            'age': 'ten',
+            'breed': 'Pamerion',
+            'color': 'White'
+        }
+
     def test_create_valid_puppy(self):
         response = client.post(
             reverse('get_post_puppies'),
@@ -90,6 +97,14 @@ class CreateNewPuppyTest(TestCase):
         response = client.post(
             reverse('get_post_puppies'),
             data=json.dumps(self.invalid_payload),
+            content_type='application/json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_create_invalid_puppy_age(self):
+        response = client.post(
+            reverse('get_post_puppies'),
+            data=json.dumps(self.invalid_payload_age),
             content_type='application/json'
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/puppy_store/puppies/views.py
+++ b/puppy_store/puppies/views.py
@@ -42,7 +42,7 @@ def get_post_puppies(request):
     if request.method == 'POST':
         data = {
             'name': request.data.get('name'),
-            'age': int(request.data.get('age')),
+            'age': request.data.get('age'),
             'breed': request.data.get('breed'),
             'color': request.data.get('color')
         }


### PR DESCRIPTION
Great tutorial.

Spotted one problem that is worth fixing... the ModelSerializer is able to validate and deal with integers passed in as strings.   Using int() results in a 500 error if you pass a bad age in.